### PR TITLE
support async process

### DIFF
--- a/src/APIResponder.jl
+++ b/src/APIResponder.jl
@@ -122,8 +122,8 @@ function process(conn::APIResponder)
             respond(conn, Nullable(conn.endpoints[cmd]), :invalid_data)
         end
     end
-    close(api.sock)
-    close(api.ctx)
+    close(conn.sock)
+    #close(conn.ctx)
     Logging.info("stopped processing.")
 end
 
@@ -153,7 +153,7 @@ function process_async(apispecs::Array, addr::AbstractString=get(ENV,"JBAPI_QUEU
     return api
 end
 
-function create_responder(apispecs::Array{Tuple, 1}, addr, bind, nid)
+function create_responder(apispecs::Array, addr, bind, nid)
     api = APIResponder(addr, Context(), bind, nid)
     for spec in apispecs
       fn = spec[1]

--- a/src/JuliaWebAPI.jl
+++ b/src/JuliaWebAPI.jl
@@ -7,7 +7,7 @@ using HttpCommon
 using HttpServer
 using Compat
 
-export APIResponder, register, process
+export APIResponder, register, process, process_async
 export APIInvoker, apicall, httpresponse, fnresponse, run_rest
 
 const ERR_CODES = @compat Dict{Symbol, Array}(:success            => [200,  0, ""],

--- a/test/asynctests.jl
+++ b/test/asynctests.jl
@@ -1,0 +1,18 @@
+using JuliaWebAPI
+using Compat
+using Logging
+
+include("srvrfn.jl")
+
+const JSON_RESP_HDRS = @compat Dict{AbstractString,AbstractString}("Content-Type" => "application/json; charset=utf-8")
+const BINARY_RESP_HDRS = @compat Dict{AbstractString,AbstractString}("Content-Type" => "application/octet-stream")
+
+const REGISTERED_APIS = [
+        (testfn1, true, JSON_RESP_HDRS),
+        (testfn2, false),
+        (testbinary, false, BINARY_RESP_HDRS)
+    ]
+
+api = process_async(REGISTERED_APIS, "tcp://127.0.0.1:9999"; bind=true, log_level=INFO)
+
+include("clnt.jl")


### PR DESCRIPTION
This PR creates a `process_async` method that allows an api server to be started as a background task on the repl. In addition, that method returns the `APIResponder` instance, which can be used to register new functions into the server. 