### PR TITLE
Properly type arrays passed over JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+*.log
+

--- a/src/APIResponder.jl
+++ b/src/APIResponder.jl
@@ -76,17 +76,17 @@ function call_api(api::APISpec, conn::APIResponder, args::Array, data::Dict{Symb
     end
 end
 
-doc"""
-    narrow_args! if a private function that processes an Array transferred
-    over JSON to a properly typed and dimensioned Julia array. Arrays
-    serialised from JSON are stored as an Array{Any}, even if all the elements
-    are members of the same concrete type, eg, Float64. This function will
-    transform such an array to an Array{Float64} type.
 
-    Further, since JSON does not have true multidimensional arrays, they are
-    transmitted as arrays containing arrays. This function will convert them to
-    a true multidimensional array in Julia.
-"""
+###
+#    over JSON to a properly typed and dimensioned Julia array. Arrays
+#    serialised from JSON are stored as an Array{Any}, even if all the elements
+#    are members of the same concrete type, eg, Float64. This function will
+#    transform such an array to an Array{Float64} type.
+#
+#    Further, since JSON does not have true multidimensional arrays, they are
+#    transmitted as arrays containing arrays. This function will convert them to
+#    a true multidimensional array in Julia.
+###
 function narrow_args!(x)
     for (i, v) in enumerate(x)
         if (typeof(v) <: AbstractArray)

--- a/src/APIResponder.jl
+++ b/src/APIResponder.jl
@@ -65,11 +65,36 @@ respond(conn::APIResponder, api::Nullable{APISpec}, status::Symbol, resp::Any=no
 
 function call_api(api::APISpec, conn::APIResponder, args::Array, data::Dict{Symbol,Any})
     try
+        if !applicable(api.fn, args...)
+            narrow_args!(args)
+        end
         result = api.fn(args...; data...)
         respond(conn, Nullable(api), :success, result)
     catch ex
         Logging.error("api_exception: $ex")
         respond(conn, Nullable(api), :api_exception)
+    end
+end
+
+doc"""
+    narrow_args! if a private function that processes an Array transferred
+    over JSON to a properly typed and dimensioned Julia array. Arrays
+    serialised from JSON are stored as an Array{Any}, even if all the elements
+    are members of the same concrete type, eg, Float64. This function will
+    transform such an array to an Array{Float64} type.
+
+    Further, since JSON does not have true multidimensional arrays, they are
+    transmitted as arrays containing arrays. This function will convert them to
+    a true multidimensional array in Julia.
+"""
+function narrow_args!(x)
+    for (i, v) in enumerate(x)
+        if (typeof(v) <: AbstractArray)
+            if (length(v) > 0 && typeof(v[1]) <: Array)
+                x[i] = hcat(x[i]...)'
+            end
+            x[i] = Base.map_promote(identity, x[i])
+        end
     end
 end
 

--- a/test/clnt.jl
+++ b/test/clnt.jl
@@ -57,4 +57,9 @@ end
 t = toc();
 println("time for $NCALLS calls to testbinary: $t secs @ $(t/NCALLS) per call")
 
+#Test Array invocation
+
+resp = apicall(apiclnt, "testArray", Float64[1.0 2.0; 3.0 4.0])
+@test fnresponse(resp) == 10
+
 close(ctx)

--- a/test/srvr.jl
+++ b/test/srvr.jl
@@ -9,7 +9,8 @@ const BINARY_RESP_HDRS = @compat Dict{AbstractString,AbstractString}("Content-Ty
 const REGISTERED_APIS = [
         (testfn1, true, JSON_RESP_HDRS),
         (testfn2, false),
-        (testbinary, false, BINARY_RESP_HDRS)
+        (testbinary, false, BINARY_RESP_HDRS),
+        (testArray, false)
     ]
 
 process(REGISTERED_APIS, "tcp://127.0.0.1:9999"; bind=true, log_level=INFO)

--- a/test/srvrfn.jl
+++ b/test/srvrfn.jl
@@ -11,3 +11,5 @@ testfn2(arg1, arg2; narg1=1, narg2=2) = testfn1(arg1, arg2; narg1=narg1, narg2=n
 
 testbinary(datalen::AbstractString) = testbinary(@compat(parse(Int,datalen)))
 testbinary(datalen::Int) = rand(UInt8, datalen)
+
+testArray(x::Array{Float64, 2}) = sum(x)


### PR DESCRIPTION
Arrays passed over JSON are serialised as `Array{Any, 1}`. This means that a method defined with `Array{Float64,1}` cannot be called with that array, even if all elements are `Float64`'s. This fixes it. 

Further, JSON has no multidimensional arrays. 2 Dimensional arrays are deserialised and serialised in JSON as Array{Array{Any, 1}, 1}. This PR converts such arrays to 2D julia arrays. 

I realise this precludes calling functions whose parameters are defined to be arrays of arrays, but I think the overwhelming majority of Julia functions are defined with multidimensional arrays, compared to methods with arrays of arrays, so this is a net win. 

cc: @jeffbezanson Using Base.map_promote here. 

cc: @viralbshah ,  @andygreenwell