### PR TITLE
make narrow_args! column-major

### DIFF
--- a/src/APIResponder.jl
+++ b/src/APIResponder.jl
@@ -91,7 +91,7 @@ function narrow_args!(x)
     for (i, v) in enumerate(x)
         if (typeof(v) <: AbstractArray)
             if (length(v) > 0 && typeof(v[1]) <: Array)
-                x[i] = hcat(x[i]...)'
+                x[i] = hcat(x[i]...)
             end
             x[i] = Base.map_promote(identity, x[i])
         end


### PR DESCRIPTION
`narrow_args!` disagrees with JSON.jl about the row/column majority of the matrix resulting in the matrix being transposed if `applicable` returns false. This makes it unstable to attempt to round-trip a matrix through here:

```julia
julia> x=JSON.parse("[[1,2,3],[4,5,6],[7,8,9]]")
3-element Array{Any,1}:
 Any[1,2,3]
 Any[4,5,6]
 Any[7,8,9]

julia> JSON.print(x)
[[1,2,3],[4,5,6],[7,8,9]]

julia> JSON.print(hcat(x...)')
[[1,4,7],[2,5,8],[3,6,9]]
```

@AndyGreenwell