### PR TITLE
fix breakage on Julia v0.5, update tests

### DIFF
--- a/src/APIResponder.jl
+++ b/src/APIResponder.jl
@@ -87,13 +87,19 @@ end
 #    transmitted as arrays containing arrays. This function will convert them to
 #    a true multidimensional array in Julia.
 ###
+if VERSION < v"0.5.0-"
+    promote_arr(x) = Base.map_promote(identity, x)
+else
+    promote_arr(x) = Base.collect_to!(similar(x, typeof(x[1])), x, 1, 1)
+end
+
 function narrow_args!(x)
     for (i, v) in enumerate(x)
         if (typeof(v) <: AbstractArray)
             if (length(v) > 0 && typeof(v[1]) <: Array)
                 x[i] = hcat(x[i]...)
             end
-            x[i] = Base.map_promote(identity, x[i])
+            x[i] = promote_arr(x[i])
         end
     end
 end

--- a/src/APIResponder.jl
+++ b/src/APIResponder.jl
@@ -170,7 +170,7 @@ function process_async(apispecs::Array, addr::AbstractString=get(ENV,"JBAPI_QUEU
 end
 
 function process(apispecs::Array, addr::AbstractString=get(ENV,"JBAPI_QUEUE",""); log_level=INFO, bind::Bool=false, nid::AbstractString=get(ENV,"JBAPI_CID",""), async::Bool=false)
-    setup_logging()
+    setup_logging(;log_level=log_level)
     Logging.debug("queue is at $addr")
     api = create_responder(apispecs, addr, bind, nid)
 

--- a/src/JuliaWebAPI.jl
+++ b/src/JuliaWebAPI.jl
@@ -20,6 +20,12 @@ const ERR_CODES = @compat Dict{Symbol, Array}(:success            => [200,  0, "
 
 const CONTROL_CMDS = @compat Dict{Symbol, Array}(:terminate => ["terminate"])
 
+if VERSION < v"0.5.0-dev+4612"
+byte2str(x) = bytestring(x)
+else
+byte2str(x) = String(x)
+end
+
 include("APIResponder.jl")
 include("APIInvoker.jl")
 include("RESTServer.jl")

--- a/src/RESTServer.jl
+++ b/src/RESTServer.jl
@@ -22,7 +22,7 @@ function parsepostdata(req, query)
         if !isempty(req.data)
             idx = findfirs(req.data, '\0')
             idx = (idx == 0) ? endof(req.data) : (idx - 1)
-            post_data = bytestring(req.data[1:idx])
+            post_data = byt2str(req.data[1:idx])
         end
     elseif isa(req.data, AbstractString)
         post_data = req.data

--- a/test/clnt.jl
+++ b/test/clnt.jl
@@ -60,6 +60,6 @@ println("time for $NCALLS calls to testbinary: $t secs @ $(t/NCALLS) per call")
 #Test Array invocation
 
 resp = apicall(apiclnt, "testArray", Float64[1.0 2.0; 3.0 4.0])
-@test fnresponse(resp) == 10
+@test fnresponse(resp) == 12
 
 close(ctx)

--- a/test/srvrfn.jl
+++ b/test/srvrfn.jl
@@ -12,4 +12,4 @@ testfn2(arg1, arg2; narg1=1, narg2=2) = testfn1(arg1, arg2; narg1=narg1, narg2=n
 testbinary(datalen::AbstractString) = testbinary(@compat(parse(Int,datalen)))
 testbinary(datalen::Int) = rand(UInt8, datalen)
 
-testArray(x::Array{Float64, 2}) = sum(x)
+testArray(x::Array{Float64, 2}) = sum(x) + x[1,2]


### PR DESCRIPTION
- update tests for #26
- fix breakage on Julia v0.5: use `Base.collect_to!` instead of `Base.map_promote` which has been removed in master
- fix logging at server: honor `log_level` passed to `process` function