### PR TITLE
allow HTTP server parameters (interface, SSL...)

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,5 +3,5 @@ ZMQ 0.3.3
 JSON
 Logging 0.3.1
 HttpCommon
-HttpServer
+HttpServer 0.0.12
 Compat 0.8.0

--- a/src/APIResponder.jl
+++ b/src/APIResponder.jl
@@ -40,8 +40,10 @@ function default_endpoint(f::Function)
     endpt
 end
 
-# register a function as API call
-# TODO: validate method belongs to module?
+"""
+Register a function as API call.
+TODO: validate method belongs to module?
+"""
 function register(conn::APIResponder, f::Function;
                   resp_json::Bool=false,
                   resp_headers::Dict=Dict{AbstractString,AbstractString}(), endpt=default_endpoint(f))
@@ -85,16 +87,17 @@ function call_api(api::APISpec, conn::APIResponder, args::Array, data::Dict{Symb
 end
 
 
-###
-#    over JSON to a properly typed and dimensioned Julia array. Arrays
-#    serialised from JSON are stored as an Array{Any}, even if all the elements
-#    are members of the same concrete type, eg, Float64. This function will
-#    transform such an array to an Array{Float64} type.
-#
-#    Further, since JSON does not have true multidimensional arrays, they are
-#    transmitted as arrays containing arrays. This function will convert them to
-#    a true multidimensional array in Julia.
-###
+#=
+narrow_args! if a private function that processes an Array transferred
+over JSON to a properly typed and dimensioned Julia array. Arrays
+serialised from JSON are stored as an Array{Any}, even if all the elements
+are members of the same concrete type, eg, Float64. This function will
+transform such an array to an Array{Float64} type.
+
+Further, since JSON does not have true multidimensional arrays, they are
+transmitted as arrays containing arrays. This function will convert them to
+a true multidimensional array in Julia.
+=#
 if VERSION < v"0.5.0-dev+3294"
     promote_arr(x) = Base.map_promote(identity, x)
 else
@@ -129,7 +132,7 @@ get_hdrs(api::Nullable{APISpec}) = !isnull(api) ? get(api).resp_headers : Dict{A
 args(msg::Dict) = get(msg, "args", [])
 data(msg::Dict) = convert(Dict{Symbol,Any}, get(msg, "vargs", Dict{Symbol,Any}()))
 
-# start processing as a server
+"""start processing as a server"""
 function process(conn::APIResponder)
     Logging.debug("processing...")
     while true

--- a/src/RESTServer.jl
+++ b/src/RESTServer.jl
@@ -92,10 +92,9 @@ type RESTServer
     end
 end
 
-function run_rest(api::APIInvoker, port::Int) 
+run_rest(api::APIInvoker, port::Int) = run_rest(api; port=port)
+function run_rest(api::APIInvoker; kwargs...)
     Logging.debug("running rest server...")
     rest = RESTServer(api)
-    run(rest.server, port)
+    run(rest.server; kwargs...)
 end
-
-


### PR DESCRIPTION
Let additional parameters for `run_rest` be passed to `HTTPServer.run`.
This will allow the HTTP server listen to a specific IP interface and enable SSL serving.