### PR TITLE
support multipart/form-data in http rpc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,13 @@ language: julia
 os:
     - osx
     - linux
+addons:
+    apt:
+        packages:
+        - libzmq3
+before_install:
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update          ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install zeromq32; fi
 julia:
     - 0.4
     - 0.5
@@ -10,7 +17,7 @@ notifications:
     email: false
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'Pkg.clone(pwd()); Pkg.build("JuliaWebAPI"); Pkg.test("JuliaWebAPI"; coverage=true)';
+    - julia -e 'Pkg.clone(pwd()); Pkg.build("ZMQ"); Pkg.build("JuliaWebAPI"); Pkg.test("JuliaWebAPI"; coverage=true)';
 after_success:
   - julia -e 'cd(Pkg.dir("JuliaWebAPI")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
 #  - julia -e 'cd(Pkg.dir("JuliaWebAPI")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())';

--- a/src/http_rpc_server.jl
+++ b/src/http_rpc_server.jl
@@ -20,7 +20,7 @@ function parsepostdata(req, query)
     post_data = ""
     if isa(req.data, Vector{UInt8})
         if !isempty(req.data)
-            idx = findfirst(req.data, '\0')
+            idx = findfirst(req.data, UInt8('\0'))
             idx = (idx == 0) ? endof(req.data) : (idx - 1)
             post_data = Compat.String(req.data[1:idx])
         end
@@ -32,6 +32,115 @@ function parsepostdata(req, query)
     merge(query, parsequerystring(post_data))
 end
 
+"""
+Handles multipart form data.
+Transfers all content as String.
+Binary files can be uplaoded by encoding them with base64 first.
+"""
+const LFLF = UInt8['\n', '\n']
+const CRLFCRLF = UInt8['\r', '\n', '\r', '\n']
+function parsepostdata(req, data_dict, multipart_boundary)
+    data = req.data
+    boundary_end = "--" * multipart_boundary * "--"
+    boundary = "--" * multipart_boundary * "\r\n"
+    Lbound = length(boundary)
+    Ldata = length(data)
+
+    boundbytes = convert(Vector{UInt8}, boundary)
+    boundbytes_end = convert(Vector{UInt8}, boundary_end)
+
+    boundloc = search(data, boundbytes, 1)
+    endpos = startpos = last(boundloc) + 1
+    parts = Vector{Vector{UInt8}}()
+    isend = false
+
+    while !isend && ((startpos + Lbound) < Ldata)
+        boundloc = search(data, boundbytes, startpos)
+        if isempty(boundloc)
+            boundloc = search(data, boundbytes_end, startpos)
+            isend = true
+        end
+        if !isempty(boundloc)
+            endpos = first(boundloc) - 3 # skip \r\n too
+
+            part = data[startpos:endpos]
+            push!(parts, part)
+
+            startpos = last(boundloc) + 1
+        end
+    end
+
+    for part in parts
+        hdrloc1 = search(part, LFLF, 1)
+        hdrloc2 = search(part, CRLFCRLF, 1)
+
+        if length(hdrloc1) == 0
+            hdrloc = hdrloc2
+        elseif length(hdrloc2) == 0
+            hdrloc = hdrloc1
+        else
+            hdrloc = (first(hdrloc1) < first(hdrloc2)) ? hdrloc1 : hdrloc2
+        end
+
+        parthdr = Compat.String(part[1:(first(hdrloc)-1)])
+        partdata = part[(last(hdrloc)+1):end]
+
+        collect_part_data(data_dict, parthdr, partdata)
+    end
+    data_dict
+end
+
+function collect_part_data(data_dict, parthdr, partdata)
+    hdrdict = parse_part_headers(parthdr)
+
+    # convert all to base64 for now
+    #content_type = header(hdrdict, "Content-Type", "application/octet-stream")
+    #istext = startswith(content_type, "text")
+
+    content_disposition = header(hdrdict, "Content-Disposition", "")
+    (isempty(content_disposition) || !startswith(content_disposition, "form-data;")) && return
+    for attr in split(content_disposition, ';')
+        ('=' in attr) || continue
+        attr = strip(attr)
+        (n,v) = split(attr, '='; limit=2)
+        if n == "name"
+            startswith(v, '"') && endswith(v, '"') && (v = v[2:(end-1)])
+            data_dict[v] = base64encode(partdata)
+        end
+    end
+end
+
+function parse_part_headers(parthdr)
+    hdrdict = Headers()
+    for hdr in split(parthdr, "\n")
+        (':' in hdr) || continue
+        (n,v) = split(hdr, ':'; limit=2)
+        hdrdict[strip(n)] = strip(v)
+    end
+    hdrdict
+end
+
+header(req::Request, name, default=nothing) = header(req.headers, name, default)
+function header(headers::Headers, name, default=nothing)
+    for (n,v) in headers
+        (lowercase(n) == lowercase(name)) && (return headers[n])
+    end
+    default
+end
+
+function get_multipart_form_boundary(req::Request)
+    content_type = header(req, "Content-Type")
+    (content_type === nothing) && (return nothing)
+    parts = split(content_type, ";")
+    (length(parts) < 2) && (return nothing)
+    (lowercase(strip(parts[1])) == "multipart/form-data") || (return false)
+    parts = split(strip(parts[2]), "=")
+    (length(parts) < 2) && (return nothing)
+    (lowercase(strip(parts[1])) == "boundary") || (return nothing)
+    parts[2]
+end
+
+# take a multipart handler
 function http_handler(api::APIInvoker, req::Request, res::Response)
     Logging.info("processing request ", req)
     
@@ -42,7 +151,12 @@ function http_handler(api::APIInvoker, req::Request, res::Response)
         else
             path = shift!(comps)
             data_dict = isempty(comps) ? Dict{Compat.UTF8String,Compat.UTF8String}() : parsequerystring(comps[1])
-            data_dict = parsepostdata(req, data_dict)
+            multipart_boundary = get_multipart_form_boundary(req)
+            if multipart_boundary === nothing
+                data_dict = parsepostdata(req, data_dict)
+            else
+                data_dict = parsepostdata(req, data_dict, multipart_boundary)
+            end
             args = split(path, '/', keep=false)
 
             if isempty(args) || !isvalidcmd(args[1])
@@ -71,6 +185,7 @@ end
 on_error(client, e) = err("HTTP error: ", e)
 on_listen(port) = Logging.info("listening on port ", port, "...")
 
+# add a multipart form handler, provide default
 type HttpRpcServer
     api::APIInvoker
     handler::HttpHandler

--- a/test/clnt.jl
+++ b/test/clnt.jl
@@ -78,6 +78,15 @@ function run_httpclnt()
     resp = JSON.parse(readall(get("http://localhost:8888/testfn1/1/2"; data=Dict(:narg1=>3, :narg2=>4))))
     @test resp["code"] == 0
     @test resp["data"] == 11
+
+    println("testing file upload...")
+    filename = "a.txt"
+    postdata = """------WebKitFormBoundaryIabcPsAlNKQmowCx\r\nContent-Disposition: form-data; name="filedata"; filename="a.txt"\r\nContent-Type: text/plain\r\n\r\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n\r\n------WebKitFormBoundaryIabcPsAlNKQmowCx\r\nContent-Disposition: form-data; name="filename"\r\n\r\na.txt\r\n------WebKitFormBoundaryIabcPsAlNKQmowCx--\r\n"""
+    headers = Dict("Content-Type"=>"multipart/form-data; boundary=----WebKitFormBoundaryIabcPsAlNKQmowCx")
+    resp = JSON.parse(readall(post("http://localhost:8888/testFile"; headers=headers, data=postdata)))
+    @test resp["code"] == 0
+    @test resp["data"] == "5,446"
+
     println("finished http rpc tests.")
 end
 

--- a/test/srvr.jl
+++ b/test/srvr.jl
@@ -19,7 +19,8 @@ function run_srvr(format=:json, async=false)
             (testfn1, true, JSON_RESP_HDRS),
             (testfn2, false),
             (testbinary, false, BINARY_RESP_HDRS),
-            (testArray, false)
+            (testArray, false),
+            (testFile, true, JSON_RESP_HDRS)
         ]
         process_async(REGISTERED_APIS, SRVR_ADDR, ; bind=true, log_level=INFO)
     else
@@ -34,6 +35,7 @@ function run_srvr(format=:json, async=false)
         register(api, testfn2)
         register(api, testbinary; resp_headers=BINARY_RESP_HDRS)
         register(api, testArray)
+        register(api, testFile; resp_json=true, resp_headers=JSON_RESP_HDRS)
 
         process(api; async=async)
     end

--- a/test/srvrfn.jl
+++ b/test/srvrfn.jl
@@ -13,3 +13,11 @@ testbinary(datalen::Compat.String) = testbinary(parse(Int,datalen))
 testbinary(datalen::Int) = rand(UInt8, datalen)
 
 testArray(x::Array{Float64, 2}) = sum(x) + x[1,2]
+
+function testFile(;filename=nothing, filedata=nothing)
+    filename = base64decode(filename)
+    filedata = base64decode(filedata)
+    #println("[", String(filename), "]")
+    #println("[", String(filedata), "]")
+    string(length(filename)) * "," * string(length(filedata))
+end


### PR DESCRIPTION
Helps support file uploads and binary content.

When a multipart form post is translated to a Julia method call:
- only POST method is handled
- each part (form field) is passed as a keyword parameter
- the "name" attribute in "Content-Disposition" header of each part is taken as the keyword parameter name (filename in "Content-Disposition" is not used during a file upload)
- the content of each part (file/field data) is base64 encoded to allow passing binary content

The example at `JuliaWebAPI/examples/filedownload` is updated to illustrate file upload as well.