### PR TITLE
pre-processor / filter for http endpoints

### DIFF
--- a/src/msgformat.jl
+++ b/src/msgformat.jl
@@ -60,7 +60,7 @@ end
 function _dict_ser(d)
     io = IOBuffer()
     serialize(io, d)
-    takebuf_array(io)
+    take!(io)
 end
 _dict_dser(b) = deserialize(IOBuffer(b))
 

--- a/test/clnt.jl
+++ b/test/clnt.jl
@@ -71,6 +71,13 @@ end
 
 function run_httpclnt()
     println("starting http rpc tests.")
+
+    resp = get("http://localhost:8888/")
+    @test resp.status == 404
+
+    resp = get("http://localhost:8888/invalidapi")
+    @test resp.status == 404
+
     resp = JSON.parse(readall(get("http://localhost:8888/testfn1/1/2")))
     @test resp["code"] == 0
     @test resp["data"] == 5
@@ -86,6 +93,10 @@ function run_httpclnt()
     resp = JSON.parse(readall(post("http://localhost:8888/testFile"; headers=headers, data=postdata)))
     @test resp["code"] == 0
     @test resp["data"] == "5,446"
+
+    println("testing preprocessor...")
+    resp = get("http://localhost:8888/testfn1/1/2"; headers = Dict("juliawebapi"=>"404"))
+    @test resp.status == 404
 
     println("finished http rpc tests.")
 end


### PR DESCRIPTION
The pre-processor / filter is run at the HTTP server side, where it has access to the complete request. It can examine headers and data and take decision whether to call the service backend or respond directly and immediately. E.g.:
````
function auth_preproc(req::Request, res::Response)
    if !validate(req)
        res.status = 401
        return false
    end
    return true
end
run_http(apiclnt, 8888, auth_preproc)
````

A pre-processor can be used to implement features like authentication, request rewriting and such.