### PR TITLE
deprecate zmq specific process apis

### DIFF
--- a/src/APIResponder.jl
+++ b/src/APIResponder.jl
@@ -174,11 +174,13 @@ function setup_logging(;log_level=INFO, nid::Compat.String=get(ENV,"JBAPI_CID","
 end
 
 function process_async(apispecs::Array, addr::Compat.String=get(ENV,"JBAPI_QUEUE",""); log_level=INFO, bind::Bool=false, nid::Compat.String=get(ENV,"JBAPI_CID",""), open::Bool=false)
+    Base.depwarn("processs_async is deprecated, use process(conn::APIResponder; async::Bool=true) instead", :process)
     process(apispecs, addr; log_level=log_level, bind=bind, nid=nid, open=open, async=true)
 end
 
 function process(apispecs::Array, addr::Compat.String=get(ENV,"JBAPI_QUEUE",""); log_level=Logging.LogLevel(get(ENV, "JBAPI_LOGLEVEL", "INFO")),
                 bind::Bool=false, nid::Compat.String=get(ENV,"JBAPI_CID",""), open::Bool=false, async::Bool=false)
+    Base.depwarn("processs(apispecs::Array,...) is deprecated, use process(conn::APIResponder; async::Bool=false) instead", :process)
     setup_logging(;log_level=log_level)
     Logging.debug("queue is at $addr")
     api = create_responder(apispecs, addr, bind, Compat.UTF8String(nid),open)
@@ -204,6 +206,7 @@ function create_responder(apispecs::Array, addr, bind, nid, open=false)
 end
 
 function process()
+    Base.depwarn("process() is deprecated, use process(conn::APIResponder; async::Bool=false) instead", :process)
     log_level = Logging.LogLevel(get(ENV, "JBAPI_LOGLEVEL", "INFO"))
     setup_logging(;log_level=log_level)
 

--- a/test/test_jbox.jl
+++ b/test/test_jbox.jl
@@ -8,5 +8,11 @@ function jb_test()
 end
 
 ENV["JBAPI_CMD"] = "Main.jb_test()"
+ENV["JBAPI_QUEUE"] = "inproc://jboxtest"
 process()
 @test jb_test_val == true
+
+fib(n::AbstractString) = fib(parse(Int, n));
+fib(n::Int) = (n < 2) ? n : (fib(n-1) + fib(n-2));
+responder = process([(fib, false)]; bind=true, async=true);
+@test isa(responder, APIResponder)


### PR DESCRIPTION
With appropriate `AbstractTransport`/`AbstractMsgFormat` implementations, JuliaWebAPI now allows using different types of transports for IPC (e.g. pipes, channels), and different message interchange formats (JSON, serialized data, dictionaries).

The methods `process(apispecs::Array, ...)` and `process_async(...)` were convenience wrappers using ZMQ and JSON. To avoid confusion in future, it seems appropriate to deprecate them in favor of explicitly specifying transport and message format.