### PR TITLE
fix race condition in test code

### DIFF
--- a/test/srvr.jl
+++ b/test/srvr.jl
@@ -49,6 +49,19 @@ function run_httprpcsrvr(fmt, tport, async=false)
     end
 end
 
+function wait_for_httpsrvr()
+    while true
+        try
+            sock = connect("localhost", 8888)
+            close(sock)
+            return
+        catch
+            Logging.info("waiting for httpserver to come up at port 8888...")
+            sleep(5)
+        end
+    end
+end
+
 # run in blocking mode if invoked with run flag
 !isempty(ARGS) && (ARGS[1] == "--runsrvr") && run_srvr(JuliaWebAPI.JSONMsgFormat(), JuliaWebAPI.ZMQTransport(SRVR_ADDR, ZMQ.REP, true), false)
 

--- a/test/test_httprpc.jl
+++ b/test/test_httprpc.jl
@@ -9,6 +9,7 @@ include("clnt.jl")
 function run_httprpctests()
     println("starting httpserver in async mode...")
     run_httprpcsrvr(JuliaWebAPI.JSONMsgFormat(), JuliaWebAPI.ZMQTransport(SRVR_ADDR, ZMQ.REP, true), true)
+    wait_for_httpsrvr()
     println("starting client...")
     run_httpclnt()
 end


### PR DESCRIPTION
Fix a race condition in HTTP interface test, where the client tries to connect before the server has started listening and fails.