### PR TITLE
Fixes Matrix parse issue

### DIFF
--- a/src/APIResponder.jl
+++ b/src/APIResponder.jl
@@ -90,8 +90,8 @@ end
 
 """call the actual API method, and send the return value back as response"""
 function call_api(api::APISpec, conn::APIResponder, args, data::Dict{Symbol,Any})
-    try
-        if !applicable(api.fn, args...)
+    try       
+        if !applicable(api.fn, args...) || ((api.fn === (*) || api.fn === (/) || api.fn === (\)) && all(x->isa(x,Vector), args))
             narrow_args!(args)
         end
         result = dynamic_invoke(conn, api.fn, args...; data...)


### PR DESCRIPTION
The behavior of `applicable()` has changed in v0.6, example:- 

Executing following code snippet in Julia v0.5 and v0.6 are resulting in different outputs
```
applicable(*, Any[Any[234.345, 23545.3, 235.245], Any[234.345, 23545.3, 235.245], Any[234.345, 2.0, 235.245]], Any[4.345, 2.0, 0.245])
```
On Julia v0.6 this returns `true`, but on v0.5, above statement returns `false`. We were using `applicable()` to determine whether the passed arguments are valid over the given method ([In here](https://github.com/JuliaWeb/JuliaWebAPI.jl/blob/c62deef9e8725f8d73d093f366e574cdc38e499c/src/APIResponder.jl#L94)) , due to aforementioned discrepancy, this condition was always failing when a Matrix was passed as argument, this PR fixes that issue.