### PR TITLE
convert params to string, better exception log

### DIFF
--- a/src/APIResponder.jl
+++ b/src/APIResponder.jl
@@ -97,7 +97,7 @@ function call_api(api::APISpec, conn::APIResponder, args, data::Dict{Symbol,Any}
         result = dynamic_invoke(conn, api.fn, args...; data...)
         respond(conn, Nullable(api), :success, result)
     catch ex
-        err("api_exception: $ex")
+        logerr("api_exception: ", ex)
         respond(conn, Nullable(api), :api_exception)
     end
 end
@@ -163,7 +163,7 @@ function process(conn::APIResponder; async::Bool=false)
             try
                 call_api(conn.endpoints[command], conn, args(conn.format, msg), data(conn.format, msg))
             catch ex
-                err("exception ", ex)
+                logerr("exception ", ex)
                 respond(conn, Nullable(conn.endpoints[command]), :invalid_data)
             end
         end
@@ -226,4 +226,11 @@ function process()
     cmd = get(ENV,"JBAPI_CMD","")
     eval(parse(cmd))
     nothing
+end
+
+function logerr(msg, ex)
+    iob = IOBuffer()
+    write(iob, msg)
+    showerror(iob, ex)
+    err(String(take!(iob)))
 end

--- a/src/http_rpc_server.jl
+++ b/src/http_rpc_server.jl
@@ -158,7 +158,7 @@ function http_handler{T,F}(apis::Channel{APIInvoker{T,F}}, preproc::Function, re
                 else
                     data_dict = parsepostdata(req, data_dict, multipart_boundary)
                 end
-                args = split(path, '/', keep=false)
+                args = map(String, split(path, '/', keep=false))
 
                 if isempty(args) || !isvalidcmd(args[1])
                     res = Response(404)

--- a/test/clnt.jl
+++ b/test/clnt.jl
@@ -60,10 +60,15 @@ function run_clnt(fmt, tport)
     t = toc();
     println("time for $NCALLS calls to testbinary: $t secs @ $(t/NCALLS) per call")
 
-    #Test Array invocation
-
+    # Test Array invocation
     resp = apicall(apiclnt, "testArray", Float64[1.0 2.0; 3.0 4.0])
     @test fnresponse(apiclnt.format, resp) == 12
+
+    # Test unknown function call
+    resp = apicall(apiclnt, "testNoSuchMethod", Float64[1.0 2.0; 3.0 4.0])
+    @test resp["code"] == 404
+    resp = apicall(apiclnt, "testArray", "no such argument")
+    @test resp["code"] == 500
 
     close(ctx)
     close(tport)


### PR DESCRIPTION
- Path parameters are sub strings when they are parsed from HTTP request. Method parameters would however unlikely to be typed as substrings (`String`/`AbstractString` is more likely if they are at all). We now convert parsed path parameters to `String` before invoking methods.
- Use `showerror` to log exceptions for more readable messages