### PR TITLE
return server exception message on api exception

### DIFF
--- a/src/APIResponder.jl
+++ b/src/APIResponder.jl
@@ -98,7 +98,7 @@ function call_api(api::APISpec, conn::APIResponder, args, data::Dict{Symbol,Any}
         respond(conn, Nullable(api), :success, result)
     catch ex
         logerr("api_exception: ", ex)
-        respond(conn, Nullable(api), :api_exception)
+        respond(conn, Nullable(api), :api_exception, string(ex))
     end
 end
 

--- a/test/clnt.jl
+++ b/test/clnt.jl
@@ -61,14 +61,23 @@ function run_clnt(fmt, tport)
     println("time for $NCALLS calls to testbinary: $t secs @ $(t/NCALLS) per call")
 
     # Test Array invocation
+    println("testing array invocation...")
     resp = apicall(apiclnt, "testArray", Float64[1.0 2.0; 3.0 4.0])
     @test fnresponse(apiclnt.format, resp) == 12
 
     # Test unknown function call
+    println("testing unknown method handling...")
     resp = apicall(apiclnt, "testNoSuchMethod", Float64[1.0 2.0; 3.0 4.0])
     @test resp["code"] == 404
     resp = apicall(apiclnt, "testArray", "no such argument")
     @test resp["code"] == 500
+    @test contains(resp["data"], "MethodError")
+
+    # Test exceptions
+    println("testing server method exception handling...")
+    resp = apicall(apiclnt, "testException")
+    @test resp["code"] == 500
+    @test contains(resp["data"]["data"], "testing exception handling")
 
     close(ctx)
     close(tport)

--- a/test/srvr.jl
+++ b/test/srvr.jl
@@ -25,6 +25,7 @@ function run_srvr(fmt, tport, async=false, open=false)
     register(api, testbinary; resp_headers=BINARY_RESP_HDRS)
     register(api, testArray)
     register(api, testFile; resp_json=true, resp_headers=JSON_RESP_HDRS)
+    register(api, testException; resp_json=true, resp_headers=JSON_RESP_HDRS)
 
     process(api; async=async)
 end

--- a/test/srvrfn.jl
+++ b/test/srvrfn.jl
@@ -21,3 +21,5 @@ function testFile(;filename=nothing, filedata=nothing)
     #println("[", String(filedata), "]")
     string(length(filename)) * "," * string(length(filedata))
 end
+
+testException() = error("testing exception handling")


### PR DESCRIPTION
This change is to return the exception encountered while executing server function back to the client.
The exception is returned in string form in the `data` field of the error response.

To customize messages at server side:
- catch exceptions and rethrow as custom exception
- override string conversion functions of exceptions