### PR TITLE
allow port reuse on HTTP end

### DIFF
--- a/test/clnt.jl
+++ b/test/clnt.jl
@@ -6,6 +6,7 @@ using Logging
 using ZMQ
 using Base.Test
 using Requests
+using JSON
 
 Logging.configure(level=INFO)
 

--- a/test/srvr.jl
+++ b/test/srvr.jl
@@ -6,6 +6,7 @@ using HttpCommon
 using Logging
 using Compat
 using ZMQ
+using JSON
 
 include("srvrfn.jl")
 


### PR DESCRIPTION
This will allow multiple HTTP servers to be multiplexed on the same port on the HTTP end.
This is useful to bypass the limitation in Julia where a `ccall` blocks all tasks in the process.

Multiple HTTP clients can get requests serviced simultaneously using more than one servers. The HTTP ends can further talk to one or more backends as needed.

`reusable_tcpserver` can be simplified once https://github.com/JuliaLang/julia/pull/24115 is merged and backported.