### PR TITLE
 updates to support HTTP.jl v0.8.0, drop Julia v0.7, fix nightly build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
     - osx
     - linux
 julia:
-    - 0.7
     - 1.0
     - nightly
 matrix:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.7
+julia 1.0
 ZMQ 0.3.3
 JSON
-HTTP 0.6.12
+HTTP 0.8.0

--- a/src/APIResponder.jl
+++ b/src/APIResponder.jl
@@ -30,8 +30,7 @@ APIResponder(addr::String, ctx::Context=Context(), bound::Bool=true, id=nothing,
 APIResponder(ip::IPv4, port::Int, ctx::Context=Context()) = APIResponder("tcp://$ip:$port", ctx)
 
 function Base.show(io::IO, x::APIResponder)
-    println(io, "JuliaWebAPI.APIResponder with $(length(x.endpoints)) endpoints:")
-    Base.show_comma_array(io, keys(x.endpoints), "","")
+    print(io, "JuliaWebAPI.APIResponder with $(length(x.endpoints)) endpoints (", join(keys(x.endpoints), ","), ")")
 end
 
 function default_endpoint(f::Function)

--- a/src/APIResponder.jl
+++ b/src/APIResponder.jl
@@ -30,7 +30,7 @@ APIResponder(addr::String, ctx::Context=Context(), bound::Bool=true, id=nothing,
 APIResponder(ip::IPv4, port::Int, ctx::Context=Context()) = APIResponder("tcp://$ip:$port", ctx)
 
 function Base.show(io::IO, x::APIResponder)
-    println(io, "JuliaWebAPI.APIResponder with endpoints:")
+    println(io, "JuliaWebAPI.APIResponder with $(length(x.endpoints)) endpoints:")
     Base.show_comma_array(io, keys(x.endpoints), "","")
 end
 
@@ -50,7 +50,7 @@ TODO: validate method belongs to module?
 function register(conn::APIResponder, f::Function;
                   resp_json::Bool=false,
                   resp_headers::Dict=Dict{String,String}(), endpt=default_endpoint(f))
-    @debug("registering", endpt)
+    @info("registering", endpt)
     conn.endpoints[endpt] = APISpec(f, resp_json, resp_headers)
     return conn # make fluent api possible
 end
@@ -147,11 +147,7 @@ function process(conn::APIResponder; async::Bool=false)
                     respond(conn, nothing, :terminate, "")
                     break
                 else
-                    @static if isdefined(Base, Symbol("@error"))
-                        @error("invalid control command ", command)
-                    else
-                        err("invalid control command ", command)
-                    end
+                    @error("invalid control command ", command)
                     continue
                 end
             end
@@ -200,9 +196,5 @@ function logerr(msg, ex)
     iob = IOBuffer()
     write(iob, msg)
     showerror(iob, ex)
-    @static if isdefined(Base, Symbol("@error"))
-        @error(String(take!(iob)))
-    else
-        err(String(take!(iob)))
-    end
+    @error(String(take!(iob)))
 end


### PR DESCRIPTION
- support HTTP.jl v0.8.0
- drop Julia 0.7 support
- fix build on Julia nightlies (`Base.show_comma_array` not available any more, use `join` instead)