### PR TITLE
[do not merge]hack away CORS violation

### DIFF
--- a/src/msgformat.jl
+++ b/src/msgformat.jl
@@ -106,6 +106,7 @@ function _dict_httpresponse(resp)
             hdrs[k] = v
         end
     end
+    hdrs["Access-Control-Allow-Origin"] = "*"
     data = get(resp, "data", "")
     respdata = isa(data, Array) ? convert(Array{UInt8}, data) :
                isa(data, Dict) ? JSON.json(data) :


### PR DESCRIPTION
I am running some frontend code that is backed by a nodejs backend server which make requests to a julia http server running `APIInvoker`. With the page rendered by server all goes fine. When the page is rendered by the client (browser) I am getting this error on browser console.
```
Access to fetch at '${addr-of-julia-http-server}' from origin '${addr-of-node-backend}' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
```

I think it is either `JuliaWebAPI`, `HTTP` or the javascript side should be responsible for setting the HTTP header here. I set the header in msgformat.jl and the browser stops complaining. But I am just hacking something together that works quickly and have zero knowledge about the network stack.

This may be more suited for an issue but maybe someone with find the hack helpful.