### PR TITLE
explicitly pass depot path during tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,9 @@ function run_test(script, flags)
     srvrscript = joinpath(dirname(@__FILE__), script)
     srvrcmd = `$(joinpath(Sys.BINDIR, "julia")) $cov_flag $inline_flag $script $flags`
     println("Running tests from ", script, "\n", "="^60)
-    ret = run(srvrcmd)
+    ret = withenv("JULIA_DEPOT_PATH"=>join(DEPOT_PATH, Sys.iswindows() ? ';' : ':')) do
+        run(srvrcmd)
+    end
     println("Finished ", script, "\n", "="^60)
     nothing
 end

--- a/test/test_clntsrvr.jl
+++ b/test/test_clntsrvr.jl
@@ -13,7 +13,9 @@ function spawn_srvr()
     srvrscript = joinpath(dirname(@__FILE__), "srvr.jl")
     srvrcmd = `$(joinpath(Sys.BINDIR, "julia")) $cov_flag $inline_flag $srvrscript --runsrvr`
     println("spawining $srvrcmd")
-    srvrproc = @static (VERSION < v"0.7.0-") ? spawn(srvrcmd) : run(srvrcmd, wait=false)
+    srvrproc = withenv("JULIA_DEPOT_PATH"=>join(DEPOT_PATH, Sys.iswindows() ? ';' : ':')) do
+        run(srvrcmd, wait=false)
+    end
 end
 
 function kill_spawned_srvr(srvrproc)


### PR DESCRIPTION
Depot path needs to be passed explicitly in tests to handle environments where they are set differently.