### PR TITLE
http server backtrace logging, update ZMQ compat, bump patch version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ julia:
     - 1.1
     - 1.2
     - 1.3
+    - 1.4
     - nightly
 matrix:
     fast_finish: true

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "480116ec-64ea-5dec-baca-db6b11e96e37"
 keywords = ["julia", "rest", "api"]
 license = "MIT"
 desc = "Julia package for deploying APIs"
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -15,7 +15,7 @@ ZMQ = "c2297ded-f4af-51ae-bb23-16f91089e4e1"
 
 [compat]
 HTTP = "0.8"
-ZMQ = "1.0"
+ZMQ = "1.0, 1.1, 1.2"
 JSON = "0.21"
 julia = "1"
 

--- a/src/http_rpc_server.jl
+++ b/src/http_rpc_server.jl
@@ -197,8 +197,8 @@ function http_handler(apis::Channel{APIInvoker{T,F}}, preproc::Function, req::HT
             end
         end
     catch e
+        @error("Exception in handler: ", exception=(e, catch_backtrace()))
         res = HTTP.Response(500)
-        @error("Exception in handler: ", exception=(e, backtrace()))
     end
     @debug("response", res)
     return res


### PR DESCRIPTION
- showing actual exception location in backtrace logged in http server backtrace logging (similar to #87)
- updated ZMQ dependency to allow compat with newer versions
- added Julia 1.4 to travis test matrix
- bumped patch version in prep for tagging a release